### PR TITLE
Fix: crash with latest Fabric API version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'maven-publish'
-    id 'fabric-loom' version '1.4-SNAPSHOT' apply false
+    id 'fabric-loom' version '1.5-SNAPSHOT' apply false
 
     // https://github.com/ReplayMod/preprocessor
     // https://github.com/Fallen-Breath/preprocessor

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 # Fabric Basic Properties
     # https://fabricmc.net/develop/
-    loader_version=0.15.1
+    loader_version=0.15.6
 
 # Mod Properties
     mod_id=enchantedshulkers

--- a/src/main/java/de/rubixdev/enchantedshulkers/config/WorldConfig.java
+++ b/src/main/java/de/rubixdev/enchantedshulkers/config/WorldConfig.java
@@ -8,6 +8,7 @@ import com.moandjiezana.toml.TomlWriter;
 import de.rubixdev.enchantedshulkers.Mod;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.File;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -81,12 +82,13 @@ public class WorldConfig {
         }
     }
 
-    private static final String ENCHANTED_ENDER_CHEST_ID = "enchantedshulkers:enchanted_ender_chest";
+    private static final String ENCHANTED_ENDER_CHEST_ID = "enchantedshulkers:enchanted_ender_chest_resourcepacks" + File.separator + "enchanted_ender_chest";
 
     private static void updateResources() {
         ResourcePackManager manager = server.getDataPackManager();
         boolean isEnderPackLoaded = manager.getEnabledNames().contains(ENCHANTED_ENDER_CHEST_ID);
         if (isEnderPackLoaded == inner.enchantableEnderChest) return;
+
 
         ArrayList<ResourcePackProfile> loadedPacks =
                 Lists.newArrayList(server.getDataPackManager().getEnabledProfiles());

--- a/src/main/java/de/rubixdev/enchantedshulkers/config/WorldConfig.java
+++ b/src/main/java/de/rubixdev/enchantedshulkers/config/WorldConfig.java
@@ -15,6 +15,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.stream.Stream;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
 import net.minecraft.resource.ResourcePackManager;
 import net.minecraft.resource.ResourcePackProfile;
 import net.minecraft.server.MinecraftServer;
@@ -82,7 +86,19 @@ public class WorldConfig {
         }
     }
 
-    private static final String ENCHANTED_ENDER_CHEST_ID = "enchantedshulkers:enchanted_ender_chest_resourcepacks" + File.separator + "enchanted_ender_chest";
+    private static final String ENCHANTED_ENDER_CHEST_ID;
+
+    static {
+        // Fabric API 0.95.4 and later use a different resource pack naming scheme
+        try {
+            ENCHANTED_ENDER_CHEST_ID = FabricLoader.getInstance().getModContainer("fabric-api").orElseThrow(RuntimeException::new).getMetadata()
+                    .getVersion().compareTo(Version.parse("0.95.4")) >= 0
+                ? "enchantedshulkers:enchanted_ender_chest_resourcepacks" + File.separator + "enchanted_ender_chest"
+                : "enchantedshulkers:enchanted_ender_chest";
+        } catch (VersionParsingException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     private static void updateResources() {
         ResourcePackManager manager = server.getDataPackManager();

--- a/versions/1.20.4/gradle.properties
+++ b/versions/1.20.4/gradle.properties
@@ -1,7 +1,7 @@
 # Fabric Properties
     # https://fabricmc.net/develop/
     minecraft_version=1.20.4
-    yarn_mappings=1.20.4+build.1
+    yarn_mappings=1.20.4+build.3
 
 # Fabric Mod Metadata
     minecraft_dependency=1.20.x
@@ -9,7 +9,7 @@
 
 # Dependencies
     # https://linkie.shedaniel.dev/
-    fabric_version=0.91.2+1.20.4
+    fabric_version=0.95.4+1.20.4
     cloth_version=13.0.114
     modmenu_version=9.0.0-pre.1
 


### PR DESCRIPTION
Fabric API v0.95.4 includes a changes in the naming of mod resource packs (FabricMC/fabric@b66dcf7). This causes a null pointer exception on line 96 in the `WorldConfig`: `enderPackProfile.getInitialPosition().insert(loadedPacks, enderPackProfile, profile -> profile, false);`. `enderPackProfile` is null here. This happens because the `ResourcePackManager` attempts to retrieve the pack with what is now an invalid name.